### PR TITLE
Add Cloudflare Turnstile verification middleware

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,5 @@ jobs:
 
       - name: Test Code
         run: uv run pytest
+        env:
+          TURNSTILE_SECRET_KEY: test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Test Code
         run: uv run pytest
         env:
-          TURNSTILE_SECRET_KEY: test
+          TURNSTILE_SECRET_KEY: 1x0000000000000000000000000000000AA

--- a/signwriting_translation/server.py
+++ b/signwriting_translation/server.py
@@ -15,13 +15,16 @@ MODEL_ID = "sign/sockeye-text-to-factored-signwriting"
 translator, _ = load_sockeye_translator(MODEL_ID, log_timing=True)
 
 TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY")
+if not TURNSTILE_SECRET_KEY:
+    msg = "Missing TURNSTILE_SECRET_KEY environment variable"
+    raise RuntimeError(msg)
 
 app = FastAPI(title="Signwriting Translation API")
 
 
 @app.middleware("http")
 async def turnstile_verification(request: Request, call_next):
-    if request.url.path == "/health" or not TURNSTILE_SECRET_KEY:
+    if request.url.path == "/health":
         return await call_next(request)
 
     token = request.headers.get("cf-turnstile-response")

--- a/signwriting_translation/server.py
+++ b/signwriting_translation/server.py
@@ -1,8 +1,10 @@
 import os
 from datetime import datetime, timezone
 
+import httpx
 import uvicorn
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from signwriting_translation.bin import load_sockeye_translator, translate
@@ -12,7 +14,30 @@ MODEL_ID = "sign/sockeye-text-to-factored-signwriting"
 
 translator, _ = load_sockeye_translator(MODEL_ID, log_timing=True)
 
+TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY", "")
+
 app = FastAPI(title="Signwriting Translation API")
+
+
+@app.middleware("http")
+async def turnstile_verification(request: Request, call_next):
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    token = request.headers.get("cf-turnstile-response")
+    if not token:
+        return JSONResponse(status_code=403, content={"error": "Missing Turnstile token"})
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+            data={"secret": TURNSTILE_SECRET_KEY, "response": token},
+        )
+
+    if not response.json().get("success"):
+        return JSONResponse(status_code=403, content={"error": "Invalid Turnstile token"})
+
+    return await call_next(request)
 
 
 class TranslationRequest(BaseModel):

--- a/signwriting_translation/server.py
+++ b/signwriting_translation/server.py
@@ -14,7 +14,9 @@ MODEL_ID = "sign/sockeye-text-to-factored-signwriting"
 
 translator, _ = load_sockeye_translator(MODEL_ID, log_timing=True)
 
-TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY", "")
+TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY")
+if not TURNSTILE_SECRET_KEY:
+    raise RuntimeError("Missing TURNSTILE_SECRET_KEY environment variable")
 
 app = FastAPI(title="Signwriting Translation API")
 

--- a/signwriting_translation/server.py
+++ b/signwriting_translation/server.py
@@ -15,15 +15,13 @@ MODEL_ID = "sign/sockeye-text-to-factored-signwriting"
 translator, _ = load_sockeye_translator(MODEL_ID, log_timing=True)
 
 TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY")
-if not TURNSTILE_SECRET_KEY:
-    raise RuntimeError("Missing TURNSTILE_SECRET_KEY environment variable")
 
 app = FastAPI(title="Signwriting Translation API")
 
 
 @app.middleware("http")
 async def turnstile_verification(request: Request, call_next):
-    if request.url.path == "/health":
+    if request.url.path == "/health" or not TURNSTILE_SECRET_KEY:
         return await call_next(request)
 
     token = request.headers.get("cf-turnstile-response")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,8 @@ from signwriting_translation.server import app
 
 client = TestClient(app)
 
+TURNSTILE_HEADERS = {"cf-turnstile-response": "test-token"}
+
 
 def test_health():
     response = client.get("/health")
@@ -19,7 +21,7 @@ def test_translate():
         "texts": ["hello"],
         "spoken_language": "en",
         "signed_language": "ase",
-    })
+    }, headers=TURNSTILE_HEADERS)
     assert response.status_code == 200
     body = response.json()
     assert body["input"] == ["hello"]
@@ -32,12 +34,12 @@ def test_translate_empty_texts():
         "texts": [],
         "spoken_language": "en",
         "signed_language": "ase",
-    })
+    }, headers=TURNSTILE_HEADERS)
     assert response.status_code == 400
 
 
 def test_translate_missing_field():
     response = client.post("/", json={
         "texts": ["hello"],
-    })
+    }, headers=TURNSTILE_HEADERS)
     assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add FastAPI HTTP middleware that verifies Cloudflare Turnstile tokens on all endpoints except `/health`
- Reads `cf-turnstile-response` header, validates against Cloudflare siteverify API using `TURNSTILE_SECRET_KEY` env var
- Returns 403 for missing or invalid tokens

## Test plan
- [ ] Set `TURNSTILE_SECRET_KEY` env var and verify requests without token return 403
- [ ] Verify requests with valid Turnstile token return 200
- [ ] Verify `/health` endpoint remains accessible without token

🤖 Generated with [Claude Code](https://claude.com/claude-code)